### PR TITLE
feat: implement change state, assign, and add tags actions for work i…

### DIFF
--- a/internal/api/workitemtypes.go
+++ b/internal/api/workitemtypes.go
@@ -72,3 +72,23 @@ func (c *Client) GetFieldDefinition(workItemTypeName, fieldReferenceName string)
 
 	return nil, fmt.Errorf("field '%s' not found for work item type '%s'", fieldReferenceName, workItemTypeName)
 }
+
+// GetWorkItemStates returns a list of valid states for a work item type
+func (c *Client) GetWorkItemStates(workItemTypeName string) ([]string, error) {
+	workItemType, err := c.GetWorkItemType(workItemTypeName)
+	if err != nil {
+		return nil, err
+	}
+
+	var states []string
+
+	if workItemType.States != nil {
+		for _, state := range *workItemType.States {
+			if state.Name != nil {
+				states = append(states, *state.Name)
+			}
+		}
+	}
+
+	return states, nil
+}

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -226,3 +226,82 @@ func RenderDetailsPane(title string, content string) string {
 	box := BoxStyle.Render(content)
 	return lipgloss.JoinVertical(lipgloss.Left, header, box)
 }
+
+// SelectionDialog displays a list of options for user selection
+type SelectionDialog struct {
+	Title       string
+	Options     []string
+	Selected    int
+	Active      bool
+	Action      string      // What action this selection is for
+	Context     interface{} // Additional context for the action
+}
+
+// NewSelectionDialog creates a new selection dialog
+func NewSelectionDialog() *SelectionDialog {
+	return &SelectionDialog{
+		Active:   false,
+		Selected: 0,
+	}
+}
+
+// Show displays the selection dialog
+func (s *SelectionDialog) Show(title string, options []string, action string, context interface{}) {
+	s.Title = title
+	s.Options = options
+	s.Action = action
+	s.Context = context
+	s.Active = true
+	s.Selected = 0
+}
+
+// Hide hides the selection dialog
+func (s *SelectionDialog) Hide() {
+	s.Active = false
+}
+
+// MoveUp moves the selection up
+func (s *SelectionDialog) MoveUp() {
+	if s.Selected > 0 {
+		s.Selected--
+	}
+}
+
+// MoveDown moves the selection down
+func (s *SelectionDialog) MoveDown() {
+	if s.Selected < len(s.Options)-1 {
+		s.Selected++
+	}
+}
+
+// SelectedValue returns the currently selected option
+func (s *SelectionDialog) SelectedValue() string {
+	if s.Selected >= 0 && s.Selected < len(s.Options) {
+		return s.Options[s.Selected]
+	}
+	return ""
+}
+
+// View renders the selection dialog
+func (s *SelectionDialog) View() string {
+	if !s.Active {
+		return ""
+	}
+
+	title := DialogTitleStyle.Render(s.Title)
+
+	var optionLines []string
+	for i, option := range s.Options {
+		if i == s.Selected {
+			optionLines = append(optionLines, SelectedOptionStyle.Render("▸ "+option))
+		} else {
+			optionLines = append(optionLines, NormalStyle.Render("  "+option))
+		}
+	}
+
+	optionsView := strings.Join(optionLines, "\n")
+	help := MutedStyle.Render("(↑/↓ or j/k: navigate, Enter: select, Esc: cancel)")
+
+	content := fmt.Sprintf("%s\n\n%s\n\n%s", title, optionsView, help)
+	return DialogBoxStyle.Render(content)
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -120,6 +120,11 @@ var (
 	InputTitleStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(lipgloss.Color(ColorPrimary))
+
+	// Selection dialog styles
+	SelectedOptionStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color(ColorPrimary))
 )
 
 // Helper functions for common styling patterns


### PR DESCRIPTION
…tems

Add functionality for the three remaining unimplemented work item actions:

- Change State (s key): Shows filterable list of valid states for the work item type with j/k or arrow key navigation
- Assign (a key): Prompts for assignee email or display name
- Add Tags (t key): Prompts for comma-separated tags, merges with existing tags

All actions execute immediately without confirmation dialogs and automatically refresh the work items list after completion.

Implementation details:
- Added GetWorkItemStates() method to API client
- Created SelectionDialog component for state selection with Vim-style navigation
- Added async functions for state change, assignment, and tag operations
- All actions use WorkItemUpdatedMsg for proper state management